### PR TITLE
fix: cannot use the cgo features needed by go-sqlite3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN go build -o polaris ./cmd/
+RUN CGO_ENABLED=1 go build -o polaris ./cmd/
 
 FROM alpine:3.20
 


### PR DESCRIPTION
@simon-ding  刚才忘记提交这一段了，最新构建的镜像会有问题